### PR TITLE
ancestryに関係するマイグレーションファイルの順番修正

### DIFF
--- a/db/migrate/20200531070215_add_ancestry_to_category_fix.rb
+++ b/db/migrate/20200531070215_add_ancestry_to_category_fix.rb
@@ -1,4 +1,4 @@
-class AddAncestryToCategory < ActiveRecord::Migration[5.2]
+class AddAncestryToCategoryFix < ActiveRecord::Migration[5.2]
   def change
     add_column :categories, :ancestry, :string
     add_index :categories, :ancestry

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_23_082323) do
+ActiveRecord::Schema.define(version: 2020_05_31_070215) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
# What
ancestryに関係するマイグレーションファイルの順番がカラム→テーブルになっていたため、
カラムのファイルを消し、新たに作成して順番をテーブル→カラムに修正

# Why
デプロイでエラーが出たため、マイグレーションファイルの順番を修正する必要があったため。