### PR TITLE
post_new_js修正

### DIFF
--- a/app/assets/javascripts/post_new.js
+++ b/app/assets/javascripts/post_new.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load', function() { 
   $('#post_images_attributes_0_image').change(function(){
     if ( !this.files.length ) {
       return;


### PR DESCRIPTION
# What
出品ページの画像アップロードがリロードしないと起動しなかったため、turbolinksに適した形に変更。

# why
turbolinksに適応するため