### PR TITLE
詳細ページ修正（条件分岐）

### DIFF
--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -27,12 +27,13 @@
             = @post.postage_payment
         .show__btn
           -if user_signed_in?
-            - if current_user.id == @post.user
-              = button_to  do
-                購入画面に進む
-            - else
+            - if current_user.id == @post.user.id
               .user_buy_button
                 購入できません。
+            - else
+              .user_buy_button
+                = button_to  do
+                  購入画面に進む
           - else
             .user_buy_button
               = button_to new_user_session_path do


### PR DESCRIPTION
商品詳細ページの購入ボタンを表示する際の条件分岐に誤りがあったため修正