### PR TITLE
遷移アクション（ログインユーザーのみ）

### DIFF
--- a/app/controllers/buy_credit_controller.rb
+++ b/app/controllers/buy_credit_controller.rb
@@ -1,6 +1,8 @@
 class BuyCreditController < ApplicationController
   require "payjp"
   before_action :set_card
+  before_action :authenticate_user!
+
 
   def index
     # すでにクレジットカードが登録しているか？

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -1,5 +1,6 @@
 class BuysController < ApplicationController
-
+  before_action :authenticate_user!
+  
   def index
     @post = Post.find(params[:post_id])
     @deli_info = DeliveryInformation.all

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -1,7 +1,8 @@
 class CreditsController < ApplicationController
   require "payjp"
   before_action :set_card
-
+  before_action :authenticate_user!
+  
   def index
     # すでにクレジットカードが登録しているか？
     if @card.present?

--- a/app/controllers/delivery_informations_controller.rb
+++ b/app/controllers/delivery_informations_controller.rb
@@ -2,6 +2,7 @@ class DeliveryInformationsController < ApplicationController
 
   before_action :set_delivery_information, except: :create
   before_action :set_item, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!
 
   def new
     if @delivery_information.present?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,8 @@
 class PostsController < ApplicationController
 
   before_action :set_post, only: [:show, :edit, :update, :destroy]
-  
+  before_action :authenticate_user!, except: [:index, :show]
+
   def index
     @posts = Post.all
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :set_profile, except: :create
+  before_action :authenticate_user!
+
 
   def index
   end

--- a/app/controllers/user_informations_controller.rb
+++ b/app/controllers/user_informations_controller.rb
@@ -1,6 +1,7 @@
 class UserInformationsController < ApplicationController
 
   before_action :set_user_information, except: :create
+  before_action :authenticate_user!
 
   def new
     if @user_information.present?


### PR DESCRIPTION
# What
悪意のあるユーザーがURLを直接入力することで遷移できないようにbefore_actionを修正
※非ログインユーザーは出品一覧（post_index),出品詳細（post_show)のみ閲覧可能

# Why
セキュリティ面強化のため